### PR TITLE
allow more args to mopidy

### DIFF
--- a/mopidy/mopidy.sh
+++ b/mopidy/mopidy.sh
@@ -20,4 +20,4 @@ if [ ${UPDATE:+x} ]; then
     pip3 freeze --local | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install -U # Upgrade all pip packages
 fi
 
-exec mopidy --config /mopidy/mopidy.conf
+exec mopidy --config /mopidy/mopidy.conf "$@"


### PR DESCRIPTION
Added an $@ style all args to the entrypoint so args may be passed
through the command in Docker and the args in k8s.

Closes #14